### PR TITLE
Update Travis-CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,20 @@
 language: php
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+  include:
+  - php: 5.4.45
+    dist: trusty
+  - php: 5.5.38
+    dist: trusty
+  - php: 5.6
+  - php: 7.0
+  - php: 7.1
+  - php: 7.2
+  - php: 7.3
+  - php: 7.4
+  - php: nightly
 install:
   - pear install package.xml
-php:
-  - 5.4
-sudo: false
-script: phpunit tests/
+script: pear run-tests tests/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/pear/Validate_Finance_CreditCard.svg?branch=master)](https://travis-ci.org/pear/Validate_Finance_CreditCard)
+
 Validate_Finance_CreditCard
 ===========================
 


### PR DESCRIPTION
This PR updates the Travis-CI configuration for this and has resulted in passing tests on all PHP versions from 5.4.45 to nightly.

https://travis-ci.org/github/MikeyMJCO/Validate_Finance_CreditCard/builds/715427210

This PR also adds a build-image to the readme linking to the Travis CI results for this repo.